### PR TITLE
Applied latest translations.

### DIFF
--- a/VulkanMod Translations/assets/vulkanmod/lang/en_us.json
+++ b/VulkanMod Translations/assets/vulkanmod/lang/en_us.json
@@ -28,6 +28,9 @@
   "vulkanmod.options.frameQueue": "Render queue size",
   "vulkanmod.options.frameQueue.tooltip": "Higher values might help stabilize frametime but will increase input lag.",
 
+  "vulkanmod.options.backfaceCulling": "Backface Culling",
+  "vulkanmod.options.backfaceCulling.tooltip": "Culls not visible block faces on the CPU improving GPU performance. To prevent increased CPU overhead enable Indirect Draw.",
+
   "vulkanmod.options.indirectDraw": "Indirect Draw",
   "vulkanmod.options.indirectDraw.tooltip": "Reduces CPU overhead but increases GPU overhead. Enabling it might help in CPU limited systems.",
 

--- a/VulkanMod Translations/assets/vulkanmod/lang/ja_jp.json
+++ b/VulkanMod Translations/assets/vulkanmod/lang/ja_jp.json
@@ -1,29 +1,43 @@
 {
   "vulkanmod.options.unknown": "不明",
+
   "vulkanmod.options.pages.video": "ビデオ設定",
   "vulkanmod.options.pages.graphics": "画質",
   "vulkanmod.options.pages.optimizations": "最適化",
   "vulkanmod.options.pages.other": "その他の設定",
-  "vulkanmod.options.buttons.apply": "適用する",
+
+  "vulkanmod.options.buttons.apply": "適用",
   "vulkanmod.options.buttons.kofi": "開発者を支援する",
+
   "vulkanmod.options.advCulling": "チャンク・カリング",
   "vulkanmod.options.advCulling.aggressive": "積極的",
   "vulkanmod.options.advCulling.conservative": "消極的",
   "vulkanmod.options.advCulling.normal": "通常",
   "vulkanmod.options.advCulling.tooltip": "表示されていないチャンクの処理を減らすことでパフォーマンスを向上させます。",
+
   "vulkanmod.options.ao.subBlock": "オン(サブブロック)",
   "vulkanmod.options.ao.subBlock.tooltip": "サブブロックに対してスムースライティングを有効にします。(実験的機能)",
+
   "vulkanmod.options.deviceSelector": "GPU選択",
   "vulkanmod.options.deviceSelector.auto": "自動",
-  "vulkanmod.options.deviceSelector.tooltip": "現在のGPU",
+  "vulkanmod.options.deviceSelector.tooltip": "使用中のGPU",
+
   "vulkanmod.options.entityCulling": "エンティティ・カリング",
   "vulkanmod.options.entityCulling.tooltip": "表示されていないエンティティの処理を減らしてパフォーマンスを向上させます。",
+
   "vulkanmod.options.frameQueue": "表示待ちフレーム数",
   "vulkanmod.options.frameQueue.tooltip": "値が高ければ高いほどフレームレートが安定しますが、入力遅延が増大します。",
+
+  "vulkanmod.options.backfaceCulling": "裏面の非表示化",
+  "vulkanmod.options.backfaceCulling.tooltip": "視界に入らないブロックの面をCPU側で非表示にし、GPUのパフォーマンスを向上させます。CPU負荷の増加を防ぐためには、「間接的な処理」を有効にしてください。",
+
   "vulkanmod.options.indirectDraw": "間接的な処理",
   "vulkanmod.options.indirectDraw.tooltip": "CPUの負荷を減らしパフォーマンスを向上させますが、GPUの負荷が増加します。CPUの性能が低い場合により効果的です。",
+
   "vulkanmod.options.refreshRate": "リフレッシュレート",
+
   "vulkanmod.options.uniqueOpaqueLayer": "地形レンダリングの最適化",
-  "vulkanmod.options.uniqueOpaqueLayer.tooltip": "不透明な地形と透明な地形での複数の描画方法を統合し減らすことで動作を最適化します。",
+  "vulkanmod.options.uniqueOpaqueLayer.tooltip": "不透明な地形と透明な地形の描画方法を統合し、動作を最適化します",
+
   "vulkanmod.options.windowedFullscreen": "フルスクリーンウィンドウ"
 }


### PR DESCRIPTION
---

### Pull Request Summary

This pull request applies the latest translations for both English and Japanese, including new translation keys and minor adjustments to the Japanese translations. The new translation keys and English translations were sourced from the latest beta release on Modrinth.

---

### English Additions
- Added the following translation keys (sourced from the latest beta release on Modrinth):
  - `vulkanmod.options.backfaceCulling`
  - `vulkanmod.options.backfaceCulling.tooltip`

---

### Japanese Additions/Modifications

**Added Keys**:
- `vulkanmod.options.backfaceCulling`: `"裏面の非表示化"`
- `vulkanmod.options.backfaceCulling.tooltip`: `"視界に入らないブロックの面をCPU側で非表示にし、GPUのパフォーマンスを向上させます。CPU負荷の増加を防ぐためには、「間接的な処理」を有効にしてください。"`

**Modifications**:
- `"vulkanmod.options.buttons.apply"`: Changed from `"適用する"` to `"適用"` for consistency in UI.
- `"vulkanmod.options.deviceSelector.tooltip"`: Changed from `"現在のGPU"` to `"使用中のGPU"` for clarity.
- `"vulkanmod.options.uniqueOpaqueLayer.tooltip"`: Simplified the text to `"不透明な地形と透明な地形の描画方法を統合し、動作を最適化します"` for readability.

---

These changes improve translation accuracy and consistency, making the mod settings more understandable for Japanese users. The new English keys and texts were obtained directly from the latest beta release on Modrinth.